### PR TITLE
Update __init__.py

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -143,14 +143,14 @@ def main(argv=None):
     )
 
     # flit install-reqs ----------------------------------------
-    parser_install = subparsers.add_parser('install-reqs',
+    parser_install_reqs = subparsers.add_parser('install-reqs',
         help="Install the package requirements",
     )
-    add_shared_install_options(parser_install)
-    parser_install.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
+    add_shared_install_options(parser_install_reqs)
+    parser_install_reqs.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
         help="Which set of dependencies to install. If --deps=develop, the extras dev, doc, and test are installed"
     )
-    parser_install.add_argument('--extras', default=(), type=lambda l: l.split(',') if l else (),
+    parser_install_reqs.add_argument('--extras', default=(), type=lambda l: l.split(',') if l else (),
         help="Install the dependencies of these (comma separated) extras additionally to the ones implied by --deps. "
              "--extras=all can be useful in combination with --deps=production, --deps=none precludes using --extras"
     )

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -221,7 +221,6 @@ def main(argv=None):
     elif args.subcmd == 'init':
         from .init import TerminalIniter
         TerminalIniter().initialise()
-        
     else:
         ap.print_help()
         sys.exit(1)

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -206,8 +206,7 @@ def main(argv=None):
         try:
             python = find_python_executable(args.python)
             Installer.from_ini_path(args.ini_file, user=args.user, python=python,
-                      symlink=args.symlink, deps=args.deps, extras=args.extras,
-                      pth=args.pth_file).install_requirements()
+                      deps=args.deps, extras=args.extras).install_requirements()
         except (ConfigError, PythonNotFoundError, common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
 

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -144,7 +144,7 @@ def main(argv=None):
 
     # flit install-reqs ----------------------------------------
     parser_install = subparsers.add_parser('install-reqs',
-        help="Install the package",
+        help="Install the package requirements",
     )
     add_shared_install_options(parser_install)
     parser_install.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -57,7 +57,14 @@ def add_shared_install_options(parser: argparse.ArgumentParser):
     parser.add_argument('--python',
         help="Target Python executable, if different from the one running flit"
     )
-
+    parser.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
+        help="Which set of dependencies to install. If --deps=develop, the extras dev, doc, and test are installed"
+    )
+    parser.add_argument('--extras', default=(), type=lambda l: l.split(',') if l else (),
+        help="Install the dependencies of these (comma separated) extras additionally to the ones implied by --deps. "
+             "--extras=all can be useful in combination with --deps=production, --deps=none precludes using --extras"
+    )
+    
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
@@ -134,26 +141,12 @@ def main(argv=None):
         help="Add .pth file for the module/package to site packages instead of copying it"
     )
     add_shared_install_options(parser_install)
-    parser_install.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
-        help="Which set of dependencies to install. If --deps=develop, the extras dev, doc, and test are installed"
-    )
-    parser_install.add_argument('--extras', default=(), type=lambda l: l.split(',') if l else (),
-        help="Install the dependencies of these (comma separated) extras additionally to the ones implied by --deps. "
-             "--extras=all can be useful in combination with --deps=production, --deps=none precludes using --extras"
-    )
 
     # flit install-reqs ----------------------------------------
     parser_install_reqs = subparsers.add_parser('install-reqs',
         help="Install the package requirements",
     )
     add_shared_install_options(parser_install_reqs)
-    parser_install_reqs.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
-        help="Which set of dependencies to install. If --deps=develop, the extras dev, doc, and test are installed"
-    )
-    parser_install_reqs.add_argument('--extras', default=(), type=lambda l: l.split(',') if l else (),
-        help="Install the dependencies of these (comma separated) extras additionally to the ones implied by --deps. "
-             "--extras=all can be useful in combination with --deps=production, --deps=none precludes using --extras"
-    )
 
     # flit init --------------------------------------------
     parser_init = subparsers.add_parser('init',

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -16,4 +16,4 @@ def test_flit_install_reqs():
     p = Popen([sys.executable, '-m', 'flit', 'install-reqs'], stdout=PIPE, stderr=STDOUT)
     out, _ = p.communicate()
     assert 'pip' in out.decode('utf-8', 'replace')
-    assert p.poll() == 1
+    assert p.poll() == 0

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -11,3 +11,9 @@ def test_flit_usage():
     out, _ = p.communicate()
     assert 'Build wheel' in out.decode('utf-8', 'replace')
     assert p.poll() == 1
+
+    def test_flit_install_reqs():
+    p = Popen([sys.executable, '-m', 'flit', 'install-reqs'], stdout=PIPE, stderr=STDOUT)
+    out, _ = p.communicate()
+    assert 'pip' in out.decode('utf-8', 'replace')
+    assert p.poll() == 1

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -12,7 +12,7 @@ def test_flit_usage():
     assert 'Build wheel' in out.decode('utf-8', 'replace')
     assert p.poll() == 1
 
-    def test_flit_install_reqs():
+def test_flit_install_reqs():
     p = Popen([sys.executable, '-m', 'flit', 'install-reqs'], stdout=PIPE, stderr=STDOUT)
     out, _ = p.communicate()
     assert 'pip' in out.decode('utf-8', 'replace')


### PR DESCRIPTION
This extends the CLI, and provides a command to an additional public function, `install_requirements()`. This will skip installing the user's code, but will still install all required dependencies.

This enables installation of dependencies without the need for separate `requirements.txt` files

`flit install-reqs`

The following command can be used instead of `pip install -r requirements.test.txt`

`flit install-reqs --deps test`